### PR TITLE
Add an implementation of Fail for Box<T> when deriving fail

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,38 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
         }
     });
 
+    let name = &s.ast().ident;
+
+    #[cfg(feature = "std")]
+    let box_fail = quote! {
+        impl ::failure::Fail for Box<#name>
+            where #name: ::failure::Fail
+        {
+            fn cause(&self) -> ::std::option::Option<&::failure::Fail> {
+                (**self).cause()
+            }
+
+            fn backtrace(&self) -> ::std::option::Option<&::failure::Backtrace> {
+                (**self).backtrace()
+            }
+        }
+    };
+
+    #[cfg(not(feature = "std"))]
+    let box_fail = quote! {
+        impl ::failure::Fail for Box<#name>
+            where #name: ::failure::Fail
+        {
+            fn cause(&self) -> ::core::option::Option<&::failure::Fail> {
+                (**self).cause()
+            }
+
+            fn backtrace(&self) -> ::core::option::Option<&::failure::Backtrace> {
+                (**self).backtrace()
+            }
+        }
+    };
+
     #[cfg(feature = "std")]
     let display = display_body(&s).map(|display_body| {
         s.bound_impl("::std::fmt::Display", quote! {
@@ -77,6 +109,7 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
 
     quote! {
         #fail
+        #box_fail
         #display
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,3 +54,21 @@ fn enum_error() {
     let s = format!("{}", EnumError::UnitVariant);
     assert_eq!(&s[..], "An error has occurred.");
 }
+
+#[derive(Fail, Debug)]
+enum RecursiveError {
+    #[fail(display = "Recursive: {}", _0)]
+    Some(#[cause] Box<RecursiveError>),
+    #[fail(display = "None")]
+    None
+}
+
+#[test]
+fn recursive_error() {
+    let s = format!("{}", RecursiveError::None);
+    assert_eq!(&s[..], "None");
+    let s = format!("{}", RecursiveError::Some(Box::new(RecursiveError::None)));
+    assert_eq!(&s[..], "Recursive: None");
+    let s = format!("{}", RecursiveError::Some(Box::new(RecursiveError::Some(Box::new(RecursiveError::None)))));
+    assert_eq!(&s[..], "Recursive: Recursive: None");
+}


### PR DESCRIPTION
This allows for recursive error types with causes.