### PR TITLE
Make the license machine-parseable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Without Boats <woboats@gmail.com>"]
 description = "derives for the failure crate"
-license = "MIT OR Apache-2.0"
+license = "MIT/Apache-2.0"
 name = "failure_derive"
 repository = "https://github.com/withoutboats/failure_derive"
 homepage = "https://boats.gitlab.io/failure"


### PR DESCRIPTION
According to http://doc.crates.io/manifest.html, multiple licenses are
to be separated by „/“. More importantly, some tools (eg. lichking)
understand „/“, but not „OR“.