### PR TITLE
Use unbound_impl instead of bound_impl.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
     });
 
     #[cfg(feature = "std")]
-    let fail = s.bound_impl("::failure::Fail", quote! {
+    let fail = s.unbound_impl("::failure::Fail", quote! {
         #[allow(unreachable_code)]
         fn cause(&self) -> ::std::option::Option<&::failure::Fail> {
             match *self { #cause_body }
@@ -41,7 +41,7 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
     });
 
     #[cfg(not(feature = "std"))]
-    let fail = s.bound_impl("::failure::Fail", quote! {
+    let fail = s.unbound_impl("::failure::Fail", quote! {
         #[allow(unreachable_code)]
         fn cause(&self) -> ::core::option::Option<&::failure::Fail> {
             match *self { #cause_body }
@@ -57,7 +57,7 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
 
     #[cfg(feature = "std")]
     let display = display_body(&s).map(|display_body| {
-        s.bound_impl("::std::fmt::Display", quote! {
+        s.unbound_impl("::std::fmt::Display", quote! {
             #[allow(unreachable_code)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 match *self { #display_body }
@@ -68,7 +68,7 @@ fn fail_derive(s: synstructure::Structure) -> quote::Tokens {
 
     #[cfg(not(feature = "std"))]
     let display = display_body(&s).map(|display_body| {
-        s.bound_impl("::core::fmt::Display", quote! {
+        s.unbound_impl("::core::fmt::Display", quote! {
             #[allow(unreachable_code)]
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match *self { #display_body }

--- a/tests/custom_type_bounds.rs
+++ b/tests/custom_type_bounds.rs
@@ -1,0 +1,42 @@
+extern crate failure;
+#[macro_use] extern crate failure_derive;
+
+use std::fmt::Debug;
+
+use failure::Fail;
+
+#[derive(Debug, Fail)]
+#[fail(display = "An error has occurred.")]
+pub struct UnboundedGenericTupleError<T: 'static + Debug + Send + Sync>(T);
+
+#[test]
+fn unbounded_generic_tuple_error() {
+    let s = format!("{}", UnboundedGenericTupleError(()));
+    assert_eq!(&s[..], "An error has occurred.");
+}
+
+#[derive(Debug, Fail)]
+#[fail(display = "An error has occurred: {}", _0)]
+pub struct FailBoundsGenericTupleError<T: Fail>(T);
+
+#[test]
+fn fail_bounds_generic_tuple_error() {
+    let error = FailBoundsGenericTupleError(UnboundedGenericTupleError(()));
+    let s = format!("{}", error);
+    assert_eq!(&s[..], "An error has occurred: An error has occurred.");
+}
+
+pub trait NoDisplay: 'static + Debug + Send + Sync {}
+
+impl NoDisplay for &'static str {}
+
+#[derive(Debug, Fail)]
+#[fail(display = "An error has occurred: {:?}", _0)]
+pub struct CustomBoundsGenericTupleError<T: NoDisplay>(T);
+
+#[test]
+fn custom_bounds_generic_tuple_error() {
+    let error = CustomBoundsGenericTupleError("more details unavailable.");
+    let s = format!("{}", error);
+    assert_eq!(&s[..], "An error has occurred: \"more details unavailable.\"");
+}


### PR DESCRIPTION
Allow the Fail trait to be derived on types with generic type parameters
that don't implement the Fail trait.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/withoutboats/failure_derive/11)
<!-- Reviewable:end -->
